### PR TITLE
CC: Advanced Math and CC: VS support

### DIFF
--- a/src/CCSharp/AdvancedMath/MMath.cs
+++ b/src/CCSharp/AdvancedMath/MMath.cs
@@ -1,0 +1,29 @@
+using CCSharp.Attributes;
+using CCSharp.ComputerCraft;
+
+namespace CCSharp.AdvancedMath;
+
+[LuaRequiredModule("AdvancedMath.mmath", "mmath")]
+public class MMath
+{
+    [LuaMethod("mmath.solveSysEq")]
+    public static double[] SolveSystemOfEquations(Func<double, double> f, Func<double, double> g, double min, double max, double steps, double tol, double closeThresh) => default;
+
+    [LuaMethod("mmath.weightedTable")]
+    public static double[] WeightedTable(double[] values, double[] weights) => default;
+
+    [LuaMethod("mmath.scamble")]
+    public static double[] Scramble(double[] t) => default;
+
+    [LuaMethod("mmath.integrateSimple")]
+    public static double IntegrateSimple(Func<double, double> f, double n, double a, double b, double init) => default;
+
+    [LuaMethod("mmath.integrateComplex")]
+    public static double IntegrateComplex(Func<double, double> f, double n, double a, double b, double init) => default;
+
+    [LuaMethod("mmath.ARC")]
+    public static double ApproximateRateOfChange(Func<double, double> f, double x, double h) => default;
+
+    [LuaMethod("mmath.solveRoot")]
+    public static double SolveRoot(Func<double, double> f, double x0, double tol) => default;
+}

--- a/src/CCSharp/AdvancedMath/MMath.cs
+++ b/src/CCSharp/AdvancedMath/MMath.cs
@@ -1,3 +1,4 @@
+using System;
 using CCSharp.Attributes;
 using CCSharp.ComputerCraft;
 
@@ -6,7 +7,7 @@ namespace CCSharp.AdvancedMath;
 /// <summary>
 /// A grab bag of linear equation solvers. Useful for finding solution using linear algebra.
 /// </summary>
-[LuaRequiredModule("AdvancedMath.mmath", "mmath")]
+[LuaRequireModule("AdvancedMath.mmath", "mmath")]
 public class MMath
 {
     /// <summary>

--- a/src/CCSharp/AdvancedMath/MMath.cs
+++ b/src/CCSharp/AdvancedMath/MMath.cs
@@ -3,27 +3,111 @@ using CCSharp.ComputerCraft;
 
 namespace CCSharp.AdvancedMath;
 
+/// <summary>
+/// A grab bag of linear equation solvers. Useful for finding solution using linear algebra.
+/// </summary>
 [LuaRequiredModule("AdvancedMath.mmath", "mmath")]
 public class MMath
 {
+    /// <summary>
+    /// Solves f(x) = g(x) over an interval by probing many starting 
+    /// points and using Newton-Raphson.
+    /// </summary>
+    /// <param name="f">The first function in the system of equations</param>
+    /// <param name="g">The second function in the system of equations</param>
+    /// <param name="min">The lower bound of the search interval</param>
+    /// <param name="max">The upper bound of the search interval</param>
+    /// <param name="steps">The number of probe seeds across the interval Needs to be greater than or equal to one.</param>
+    /// <param name="tol">The tolerance forwarded to the root finder</param>
+    /// <param name="closeThresh">The distance threshold  used to consider two roots identical</param>
+    /// <returns>An array of root approximations found within [min, max]</returns>
     [LuaMethod("mmath.solveSysEq")]
     public static double[] SolveSystemOfEquations(Func<double, double> f, Func<double, double> g, double min, double max, double steps, double tol, double closeThresh) => default;
+    [LuaMethod("mmath.solveSysEq")]
+    public static double[] SolveSystemOfEquations(Func<double, double> f, Func<double, double> g, double min, double max, double steps, double tol) => default;
+    [LuaMethod("mmath.solveSysEq")]
+    public static double[] SolveSystemOfEquations(Func<double, double> f, Func<double, double> g, double min, double max, double steps) => default;
 
+    /// <summary>
+    /// Expand a set of values according to integer weights.
+    /// 
+    /// For each index i in values, values[i] is inserted into the 
+    /// returned array weights[i] times.
+    /// </summary>
+    /// <param name="values">Array of values to repeat</param>
+    /// <param name="weights">Array of integer weights</param>
+    /// <returns>Array with values repeated according to weights</returns>
     [LuaMethod("mmath.weightedTable")]
     public static double[] WeightedTable(double[] values, double[] weights) => default;
 
+    /// <summary>
+    /// Shuffle/randomize the array and return the new scrambled array.
+    /// 
+    /// This function mutates the input array by repeatedly removing each
+    /// element and inserting it at a random position. It is a simple shuffle and
+    /// not an in-place Fisher–Yates implementation.
+    /// </summary>
+    /// <param name="t">The array to scramble</param>
+    /// <returns>The new scrambled array</returns>
     [LuaMethod("mmath.scamble")]
     public static double[] Scramble(double[] t) => default;
 
+    /// <summary>
+    /// Numerically integrate f(x) on [a, b] using the trapezoid rule.
+    /// </summary>
+    /// <param name="f">The function to integrate</param>
+    /// <param name="n">The number of subdivision. Must be greater than zero.</param>
+    /// <param name="a">The lower bound</param>
+    /// <param name="b">The upper bound</param>
+    /// <param name="init">The optional initial accumulator</param>
+    /// <returns>The approximation of the integral of f(x) on [a, b]</returns>
     [LuaMethod("mmath.integrateSimple")]
     public static double IntegrateSimple(Func<double, double> f, double n, double a, double b, double init) => default;
+    [LuaMethod("mmath.integrateSimple")]
+    public static double IntegrateSimple(Func<double, double> f, double n, double a, double b) => default;
 
+    /// <summary>
+    /// Numerically integrate f(x) on [a, b] using Simpson-like parabolic rule.
+    /// 
+    /// If n is odd it is decremented to make it even. This method is generally
+    /// more accurate than the trapezoid rule for smooth functions.
+    /// </summary>
+    /// <param name="f">The function to integrate</param>
+    /// <param name="n">The number of subdivision. Must be greater than zero.</param>
+    /// <param name="a">The lower bound</param>
+    /// <param name="b">The upper bound</param>
+    /// <param name="init">The optional initial accumulator</param>
+    /// <returns>The approximation of the integral of f(x) on [a, b]</returns>
     [LuaMethod("mmath.integrateComplex")]
     public static double IntegrateComplex(Func<double, double> f, double n, double a, double b, double init) => default;
+    [LuaMethod("mmath.integrateComplex")]
+    public static double IntegrateComplex(Func<double, double> f, double n, double a, double b) => default;
 
+    /// <summary>
+    /// Approximate the derivative (central difference) of a single-variable function.
+    /// 
+    /// Computes (f(x + h) - f(x - h)) / (2 * h). Use smaller h to approach the analytical
+    /// derivative but beware of numerical round-off for extremely small h.
+    /// </summary>
+    /// <param name="f">The function to differentiate</param>
+    /// <param name="x">The point at which to evalluate the derivative</param>
+    /// <param name="h">The step size</param>
+    /// <returns>The numerical derivative approximation</returns>
     [LuaMethod("mmath.ARC")]
     public static double ApproximateRateOfChange(Func<double, double> f, double x, double h) => default;
 
+    [LuaMethod("mmath.ARC")]
+    public static double ApproximateRateOfChange(Func<double, double> f, double x) => default;
+
+    /// <summary>
+    /// Find a root using Newton–Raphson starting from x0.
+    /// 
+    /// Attempts up to 500 iterations. The derivative is approximated using ApproximateRateOfChange.
+    /// </summary>
+    /// <param name="f">The function for which to find a root</param>
+    /// <param name="x0">The initial guess</param>
+    /// <param name="tol">The convergence tolerance for changes in x</param>
+    /// <returns>On success returns the root (a number), otherwise returns null to indicate failure.</returns>
     [LuaMethod("mmath.solveRoot")]
     public static double SolveRoot(Func<double, double> f, double x0, double tol) => default;
 }

--- a/src/CCSharp/AdvancedMath/Matrix.cs
+++ b/src/CCSharp/AdvancedMath/Matrix.cs
@@ -1,0 +1,308 @@
+using CCSharp.Attributes;
+using CCSharp.ComputerCraft;
+
+namespace CCSharp.AdvancedMath;
+
+public class Matrix
+{
+    /// <summary>
+    /// Represents a single row in the Matrix.
+    /// </summary>
+    class Row
+    {
+        /// <summary>
+        /// Gets or sets the value at the specified column in this row.
+        /// </summary>
+        /// <param name="col">The column index (1-based).</param>
+        /// <returns>The value at the specified column.</returns>
+        public double this[int col]
+        {
+            get => default;
+            set { }
+        }
+    }
+
+    [LuaProperty("rows")]
+    public int Rows { get; set; }
+    [LuaProperty("columns")]
+    public int Columns { get; set; }
+
+    /// <summary>
+    /// Constructs a new Matrix with the given number of rows and columns, filling it using the provided function.
+    /// </summary>
+    /// <param name="rows">The number of rows in the matrix.</param>
+    /// <param name="columns">The number of columns in the matrix.</param>
+    /// <param name="function">A function that takes in a row and column index (1-based) and returns the value at that position.</param>
+    [LuaConstructor("matrix.new")]
+    public Matrix(int rows, int columns, Func<int, int> function) { }
+
+    /// <summary>
+    /// Constructs a new Matrix with the given number of rows and columns, filling it with the provided value.
+    /// </summary>
+    /// <param name="rows">The number of rows in the matrix.</param>
+    /// <param name="columns">The number of columns in the matrix.</param>
+    /// <param name="fill">The value to fill the matrix with.</param>
+    [LuaConstructor("matrix.new")]
+    public Matrix(int rows, int columns, double fill) { }
+
+    /// <summary>
+    /// Constructs a new Matrix with the given 2D array.
+    /// </summary>
+    /// <param name="array">The 2D array to initialize the matrix with.</param>
+    [LuaConstructor("matrix.from2DArray")]
+    public Matrix(double[][] array) { }
+
+    /// <summary>
+    /// Constructs a new vector Matrix as either a single row or column/
+    /// </summary>
+    /// <param name="vector">The Vector to convert to a Matrix.</param>
+    /// <param name="row">If true, the vector Matrix will be a single row, otherwise it will be a single column.</param>
+    [LuaConstructor("matrix.fromVector")]
+    public Matrix(Vector3 vector, bool row) { }
+
+    /// <summary>
+    /// Constructs a new 3x3 rotation Matrix from the given Quaternion.
+    /// </summary>
+    /// <param name="quaternion">The Quaternion to convert to a 3x3 rotation matrix.</param>
+    [LuaConstructor("matrix.fromQuaternion")]
+    public Matrix(Quaternion quaternion) { }
+
+    /// <summary>
+    /// Constructs a new identity Matrix with the given number of rows and columns.
+    /// </summary>
+    /// <param name="rows">The number of rows in the matrix.</param>
+    /// <param name="columns">The number of columns in the matrix.</param>
+    [LuaMethod("matrix.identity")]
+    public Matrix(int rows, int columns) { }
+
+    /// <summary>
+    /// Solves the equation Ax = b for x, where A is a Matrix and b is a column vector.
+    /// </summary>
+    /// <param name="A">The matrix A.</param>
+    /// <param name="b">The column vector b.</param>
+    /// <param name="tolerance">The tolerance for the solution.</param>
+    /// <returns>A tuple containing the solution matrix and a warning string if applicable.</returns>
+    [LuaMethod("matrix.solve"), CallMethodFlags.WrapAsTable]
+    public static (Matrix Solution, string Warning) Solve(Matrix A, Matrix b, double tolerance) => default;
+
+    /// <summary>
+    /// Solves the equation Ax = b for x, where A is a Matrix and b is a column vector.
+    /// </summary>
+    /// <param name="A">The matrix A.</param>
+    /// <param name="b">The column vector b.</param>
+    /// <returns>A tuple containing the solution matrix and a warning string if applicable.</returns>
+    [LuaMethod("matrix.solve"), CallMethodFlags.WrapAsTable]
+    public static (Matrix Solution, string Warning) Solve(Matrix A, Matrix b) => default;
+
+    /// <summary>
+    /// Gets or sets the value at the specified row.
+    /// </summary>
+    /// <param name="row">The row index (1-based).</param>
+    /// <returns>The Row object representing the specified row.</returns>
+    public Row this[int row]
+    {
+        get => default;
+        set { }
+    }
+
+    /// <summary>
+    /// Get the length (also referred to as magnitude) of this Matrix.
+    /// </summary>
+    /// <returns>The length of this matrix.</returns>
+    [LuaMethod("length")]
+    public double Length() => default;
+
+    /// <summary>
+    /// Gets the minor matrix by removing the specified row and column.
+    /// </summary>
+    /// <param name="row">The row to remove (1-based).</param>
+    /// <param name="col">The column to remove (1-based).</param>
+    /// <returns>The minor matrix.</returns>
+    [LuaMethod("minor")]
+    public Matrix Minor(int row, int col) => default;
+
+    /// <summary>
+    /// Calculates the determinant of the matrix.
+    /// </summary>
+    /// <returns>The determinant value.</returns>
+    [LuaMethod("determinant")]
+    public double Determinant() => default;
+
+    /// <summary>
+    /// Transposes the matrix, swapping rows and columns.
+    /// </summary>
+    /// <returns>The transposed matrix.</returns>
+    [LuaMethod("transpose")]
+    public Matrix Transpose() => default;
+
+    /// <summary>
+    /// Calculates the cofactor matrix.
+    /// </summary>
+    /// <returns>The cofactor matrix.</returns>
+    [LuaMethod("cofactor")]
+    public Matrix Cofactor() => default;
+
+    /// <summary>
+    /// Calculates the adjugate matrix.
+    /// </summary>
+    /// <returns>The adjugate matrix.</returns>
+    [LuaMethod("adjugate")]
+    public Matrix Adjugate() => default;
+
+    /// <summary>
+    /// Inverts the matrix.
+    /// </summary>
+    /// <returns>The inverted matrix.</returns>
+    [LuaMethod("inverse")]
+    public Matrix Inverse() => default;
+
+    /// <summary>
+    /// Calculates the trace of the matrix.
+    /// </summary>
+    /// <returns>The trace value.</returns>
+    [LuaMethod("trace")]
+    public double Trace() => default;
+
+    /// <summary>
+    /// Calculates the rank of the matrix.
+    /// </summary>
+    /// <returns>The rank value.</returns>
+    [LuaMethod("rank")]
+    public int Rank() => default;
+
+    /// <summary>
+    /// Gets the Frobenius norm of the matrix.
+    /// </summary>
+    /// <returns>The Frobenius norm value.</returns>
+    [LuaMethod("frobeniusNorm")]
+    public double FrobeniusNorm() => default;
+
+    /// <summary>
+    /// Gets the maximum norm of the matrix.
+    /// </summary>
+    /// <returns>The maximum norm value.</returns>
+    [LuaMethod("maxNorm")]
+    public double MaxNorm() => default;
+
+    /// <summary>
+    /// Performs the Hadamard product (element-wise multiplication) with another matrix.
+    /// </summary>
+    /// <param name="b">The other matrix.</param>
+    /// <returns>The resulting matrix from the Hadamard product.</returns>
+    [LuaMethod("hadamardProduct")]
+    public Matrix HadamardProduct(Matrix b) => default;
+
+    /// <summary>
+    /// Performs element-wise division with another matrix.
+    /// </summary>
+    /// <param name="b">The other matrix.</param>
+    /// <returns>The resulting matrix from the element-wise division.</returns>
+    [LuaMethod("elementwiseDiv")]
+    public Matrix ElementwiseDiv(Matrix b) => default;
+
+    /// <summary>
+    /// Checks if the matrix is symmetric.
+    /// </summary>
+    /// <returns>True if the matrix is symmetric, otherwise false.</returns>
+    [LuaMethod("isSymmetric")]
+    public bool IsSymmetric() => default;
+
+    /// <summary>
+    /// Checks if the matrix is diagonal.
+    /// </summary>
+    /// <returns>True if the matrix is diagonal, otherwise false.</returns>
+    [LuaMethod("isDiagonal")]
+    public bool IsDiagonal() => default;
+
+    /// <summary>
+    /// Checks if the matrix is an identity matrix.
+    /// </summary>
+    /// <returns>True if the matrix is identity, otherwise false.</returns>
+    [LuaMethod("isIdentity")]
+    public bool IsIdentity() => default;
+
+    /// <summary>
+    /// Creates a clone of the matrix.
+    /// </summary>
+    /// <returns>The cloned matrix.</returns>
+    [LuaMethod("clone")]
+    public Matrix Clone() => default;
+
+    /// <summary>
+    /// Performs LU Decomposition of the matrix.
+    /// </summary>
+    /// <returns>The L and U matrices along with the permutation array P.</returns>
+    [LuaMethod("luDecomposition", CallMethodFlags.WrapAsTable)]
+    public (Matrix L, Matrix U, int[] P) LuDecomposition() => default;
+
+    /// <summary>
+    /// Flattens the matrix into a one-dimensional array in row-major order.
+    /// </summary>
+    /// <returns>The flattened array.</returns>
+    [LuaMethod("flatten")]
+    public double[] Flatten() => default;
+
+    /// <summary>
+    /// Reshapes the matrix to the specified number of rows and columns.
+    /// </summary>
+    /// <param name="rows">The number of rows in the reshaped matrix.</param>
+    /// <param name="columns">The number of columns in the reshaped matrix.</param
+    /// <returns>The reshaped matrix.</returns>
+    [LuaMethod("reshape")]
+    public Matrix Reshape(int rows, int columns) => default;
+
+    /// <summary>
+    /// Gets a submatrix defined by the specified row and column ranges.
+    /// </summary>
+    /// <param name="r1">The starting row index (1-based).</param>
+    /// <param name="r2">The ending row index (1-based).</param>
+    /// <param name="c1">The starting column index (1-based).</param>
+    /// <param name="c2">The ending column index (1-based).</param>
+    /// <returns>The submatrix.</returns>
+    [LuaMethod("submatrix")]
+    public Matrix Submatrix(int r1, int r2, int c1, int c2) => default;
+
+    /// <summary>
+    /// Stacks another matrix vertically below this matrix.
+    /// </summary>
+    /// <param name="other">The matrix to stack below.</param>
+    /// <returns>The resulting stacked matrix.</returns>
+    [LuaMethod("vstack")]
+    public Matrix Vstack(Matrix other) => default;
+
+    /// <summary>
+    /// Stacks another matrix horizontally beside this matrix.
+    /// </summary>
+    /// <param name="other">The matrix to stack beside.</param>
+    /// <returns>The resulting stacked matrix.</returns>
+    [LuaMethod("hstack")]
+    public Matrix Hstack(Matrix other) => default;
+
+    /// <summary>
+    /// Gets the one norm of the matrix.
+    /// </summary>
+    /// <returns>The one norm value.</returns>
+    [LuaMethod("oneNorm")]
+    public double OneNorm() => default;
+
+    /// <summary>
+    /// Gets the two norm of the matrix.
+    /// </summary>
+    /// <returns>The two norm value.</returns>
+    [LuaMethod("twoNorm")]
+    public double TwoNorm() => default;
+
+    /// <summary>
+    /// Gets the infinity norm of the matrix.
+    /// </summary>
+    /// <returns>The infinity norm value.</returns>
+    [LuaMethod("infinityNorm")]
+    public double InfinityNorm() => default;
+
+    /// <summary>
+    /// Gets the condition number of the matrix.
+    /// </summary>
+    /// <returns>The condition number value.</returns>
+    [LuaMethod("conditionNumber")]
+    public double ConditionNumber() => default;
+}

--- a/src/CCSharp/AdvancedMath/Matrix.cs
+++ b/src/CCSharp/AdvancedMath/Matrix.cs
@@ -74,7 +74,7 @@ public class Matrix
     /// </summary>
     /// <param name="rows">The number of rows in the matrix.</param>
     /// <param name="columns">The number of columns in the matrix.</param>
-    [LuaMethod("matrix.identity")]
+    [LuaConstructor("matrix.identity")]
     public Matrix(int rows, int columns) { }
 
     /// <summary>

--- a/src/CCSharp/AdvancedMath/Matrix.cs
+++ b/src/CCSharp/AdvancedMath/Matrix.cs
@@ -1,5 +1,7 @@
+using System;
 using CCSharp.Attributes;
 using CCSharp.ComputerCraft;
+using CCSharp.RedIL.Resolving.CommonResolvers;
 
 namespace CCSharp.AdvancedMath;
 
@@ -8,7 +10,7 @@ public class Matrix
     /// <summary>
     /// Represents a single row in the Matrix.
     /// </summary>
-    class Row
+    public class Row
     {
         /// <summary>
         /// Gets or sets the value at the specified column in this row.
@@ -82,7 +84,7 @@ public class Matrix
     /// <param name="b">The column vector b.</param>
     /// <param name="tolerance">The tolerance for the solution.</param>
     /// <returns>A tuple containing the solution matrix and a warning string if applicable.</returns>
-    [LuaMethod("matrix.solve"), CallMethodFlags.WrapAsTable]
+    [LuaMethod("matrix.solve", CallMethodFlags.WrapAsTable)]
     public static (Matrix Solution, string Warning) Solve(Matrix A, Matrix b, double tolerance) => default;
 
     /// <summary>
@@ -91,7 +93,7 @@ public class Matrix
     /// <param name="A">The matrix A.</param>
     /// <param name="b">The column vector b.</param>
     /// <returns>A tuple containing the solution matrix and a warning string if applicable.</returns>
-    [LuaMethod("matrix.solve"), CallMethodFlags.WrapAsTable]
+    [LuaMethod("matrix.solve", CallMethodFlags.WrapAsTable)]
     public static (Matrix Solution, string Warning) Solve(Matrix A, Matrix b) => default;
 
     /// <summary>

--- a/src/CCSharp/AdvancedMath/Matrix.cs
+++ b/src/CCSharp/AdvancedMath/Matrix.cs
@@ -34,7 +34,7 @@ public class Matrix
     /// <param name="columns">The number of columns in the matrix.</param>
     /// <param name="function">A function that takes in a row and column index (1-based) and returns the value at that position.</param>
     [LuaConstructor("matrix.new")]
-    public Matrix(int rows, int columns, Func<int, int> function) { }
+    public Matrix(int rows, int columns, Func<int, int, double> function) { }
 
     /// <summary>
     /// Constructs a new Matrix with the given number of rows and columns, filling it with the provided value.

--- a/src/CCSharp/AdvancedMath/PID.cs
+++ b/src/CCSharp/AdvancedMath/PID.cs
@@ -66,7 +66,7 @@ public abstract class PID<T, Y>
     /// Disables the clamps on the control output
     /// </summary>
     [LuaMethod("clampOutput")]
-    public void ClampOutput() => default;
+    public void ClampOutput() { }
 
     /// <summary>
     /// Assigns the limits on the Integral

--- a/src/CCSharp/AdvancedMath/PID.cs
+++ b/src/CCSharp/AdvancedMath/PID.cs
@@ -1,0 +1,49 @@
+using CCSharp.Attributes;
+using CCSharp.ComputerCraft;
+
+namespace CCSharp.AdvancedMath;
+
+[LuaRequiredModule("AdvancedMath.pid", "pid")]
+public class PID<T, Y>
+{
+    [LuaProperty("sp")] public T SetPoint { get; set; }
+    [LuaProperty("kp")] public double KP { get; set; }
+    [LuaProperty("ki")] public double KI { get; set; }
+    [LuaProperty("kd")] public double KD { get; set; }
+    [LuaProperty("discrete")] public bool Discrete { get; set; }
+    [LuaProperty("integral")] public T Integral { get; set; }
+    [LuaProperty("prev_error")] public T PreviousError { get; set; }
+
+    private PID(T target, double p, double i, double d, bool discrete) { }
+
+    [LuaMethod("step")]
+    public Y Step(T value, double dt) => default;
+    [LuaMethod("step")]
+    public Y Step(T value) => default;
+
+    [LuaMethod("clampOutput")]
+    public void ClampOutput(double min, double max) => default;
+    [LuaMethod("clampOutput")]
+    public void ClampOutput() => default;
+
+    [LuaMethod("limitIntegral")]
+    public void LimitIntegral(double min, double max) => default;
+    [LuaMethod("limitIntegral")]
+    public void LimitIntegral() => default;
+
+    public class Scalar : PID<double, double> 
+    {
+        [LuaConstructor("pid.new")]
+        public Scalar(T target, double p, double i, double d, bool discrete) : base(target, p, i, d, discrete) { }
+    }
+    public class Vector : PID<Vector3, Vector3> 
+    {
+        [LuaConstructor("pid.new")]
+        public Vector(T target, double p, double i, double d, bool discrete) : base(target, p, i, d, discrete) { }
+    }
+    public class Quat : PID<Quaternion, Vector3>
+    {
+        [LuaConstructor("pid.new")]
+        public Quat(T target, double p, double i, double d, bool discrete) : base(target, p, i, d, discrete) { }
+    }
+}

--- a/src/CCSharp/AdvancedMath/PID.cs
+++ b/src/CCSharp/AdvancedMath/PID.cs
@@ -7,84 +7,85 @@ namespace CCSharp.AdvancedMath;
 /// A basic PID type and common PID operations. This may be useful when working with control systems.
 /// </summary>
 [LuaRequireModule("AdvancedMath.pid", "pid")]
-public abstract class PID<T, Y>
+public static class PID
 {
-    /// <summary>
-    /// The setpoint for the PID to reach
-    /// </summary>
-    [LuaProperty("sp")] public T SetPoint { get; set; }
-    /// <summary>
-    /// The proportional gain - how aggressively to respond to the current error
-    /// </summary>
-    [LuaProperty("kp")] public double KP { get; set; }
-    /// <summary>
-    /// The integral gain - how aggressively to eliminate accumulated error
-    /// </summary>
-    [LuaProperty("ki")] public double KI { get; set; }
-    /// <summary>
-    /// The derivative gain - how aggressively to dampen the rate of change
-    /// </summary>
-    [LuaProperty("kd")] public double KD { get; set; }
-    /// <summary>
-    /// Whether to treat the PID as discrete or continuous
-    /// </summary>
-    [LuaProperty("discrete")] public bool Discrete { get; set; }
-    /// <summary>
-    /// The internal Integral being influenced each step
-    /// </summary>
-    [LuaProperty("integral")] public T Integral { get; set; }
-    /// <summary>
-    /// The error from the previous step
-    /// </summary>
-    [LuaProperty("prev_error")] public T PreviousError { get; set; }
+    public abstract class BasePID<T, Y>(T target, double p, double i, double d, bool discrete)
+    {
+        /// <summary>
+        /// The setpoint for the PID to reach
+        /// </summary>
+        [LuaProperty("sp")] public T SetPoint { get; set; }
+        /// <summary>
+        /// The proportional gain - how aggressively to respond to the current error
+        /// </summary>
+        [LuaProperty("kp")] public double KP { get; set; }
+        /// <summary>
+        /// The integral gain - how aggressively to eliminate accumulated error
+        /// </summary>
+        [LuaProperty("ki")] public double KI { get; set; }
+        /// <summary>
+        /// The derivative gain - how aggressively to dampen the rate of change
+        /// </summary>
+        [LuaProperty("kd")] public double KD { get; set; }
+        /// <summary>
+        /// Whether to treat the PID as discrete or continuous
+        /// </summary>
+        [LuaProperty("discrete")] public bool Discrete { get; set; }
+        /// <summary>
+        /// The internal Integral being influenced each step
+        /// </summary>
+        [LuaProperty("integral")] public T Integral { get; set; }
+        /// <summary>
+        /// The error from the previous step
+        /// </summary>
+        [LuaProperty("prev_error")] public T PreviousError { get; set; }
 
-    private PID(T target, double p, double i, double d, bool discrete) { }
+        /// <summary>
+        /// Performs a PID control step
+        /// </summary>
+        /// <param name="value">The current value being measured</param>
+        /// <param name="dt">The time since the last step</param>
+        /// <returns>The control output</returns>
+        [LuaMethod("step")]
+        public Y Step(T value, double dt) => default;
+        /// <summary>
+        /// Performs a PID control step
+        /// </summary>
+        /// <param name="value">The current value being measured</param>
+        [LuaMethod("step")]
+        public Y Step(T value) => default;
 
-    /// <summary>
-    /// Performs a PID control step
-    /// </summary>
-    /// <param name="value">The current value being measured</param>
-    /// <param name="dt">The time since the last step</param>
-    /// <returns>The control output</returns>
-    [LuaMethod("step")]
-    public Y Step(T value, double dt) => default;
-    /// <summary>
-    /// Performs a PID control step
-    /// </summary>
-    /// <param name="value">The current value being measured</param>
-    [LuaMethod("step")]
-    public Y Step(T value) => default;
+        /// <summary>
+        /// Assigns the clamps on the control output
+        /// </summary>
+        /// <param name="min">The minimum control output</param>
+        /// <param name="max">The maximum control output</param>
+        [LuaMethod("clampOutput")]
+        public void ClampOutput(double min, double max) { }
+        /// <summary>
+        /// Disables the clamps on the control output
+        /// </summary>
+        [LuaMethod("clampOutput")]
+        public void ClampOutput() { }
 
-    /// <summary>
-    /// Assigns the clamps on the control output
-    /// </summary>
-    /// <param name="min">The minimum control output</param>
-    /// <param name="max">The maximum control output</param>
-    [LuaMethod("clampOutput")]
-    public void ClampOutput(double min, double max) { }
-    /// <summary>
-    /// Disables the clamps on the control output
-    /// </summary>
-    [LuaMethod("clampOutput")]
-    public void ClampOutput() { }
-
-    /// <summary>
-    /// Assigns the limits on the Integral
-    /// </summary>
-    /// <param name="min">The minimum integral limit</param>
-    /// <param name="max">The maximum integral limit</param>
-    [LuaMethod("limitIntegral")]
-    public void LimitIntegral(double min, double max) { }
-    /// <summary>
-    /// Disables the limits on the Integral
-    /// </summary>
-    [LuaMethod("limitIntegral")]
-    public void LimitIntegral() { }
+        /// <summary>
+        /// Assigns the limits on the Integral
+        /// </summary>
+        /// <param name="min">The minimum integral limit</param>
+        /// <param name="max">The maximum integral limit</param>
+        [LuaMethod("limitIntegral")]
+        public void LimitIntegral(double min, double max) { }
+        /// <summary>
+        /// Disables the limits on the Integral
+        /// </summary>
+        [LuaMethod("limitIntegral")]
+        public void LimitIntegral() { }
+    }
 
     /// <summary>
     /// A Scalar PID for handling doubles
     /// </summary>
-    public class Scalar : PID<double, double> 
+    public class Scalar : BasePID<double, double>
     {
         /// <summary>
         /// Constructs a new Scalar PID Controller
@@ -100,7 +101,7 @@ public abstract class PID<T, Y>
     /// <summary>
     /// A Vector PID for handling Vectors
     /// </summary>
-    public class Vector : PID<Vector3, Vector3> 
+    public class Vector : BasePID<Vector3, Vector3> 
     {
         /// <summary>
         /// Constructs a new Vector PID Controller
@@ -116,7 +117,7 @@ public abstract class PID<T, Y>
     /// <summary>
     /// A Quaternion PID for handling Quaternion. Step outputs the angular velocity as the control output.
     /// </summary>
-    public class Quat : PID<Quaternion, Vector3>
+    public class Quat : BasePID<Quaternion, Vector3>
     {
         /// <summary>
         /// Constructs a new Quaternion PID Controller

--- a/src/CCSharp/AdvancedMath/PID.cs
+++ b/src/CCSharp/AdvancedMath/PID.cs
@@ -3,46 +3,129 @@ using CCSharp.ComputerCraft;
 
 namespace CCSharp.AdvancedMath;
 
+/// <summary>
+/// A basic PID type and common PID operations. This may be useful when working with control systems.
+/// </summary>
 [LuaRequiredModule("AdvancedMath.pid", "pid")]
 public abstract class PID<T, Y>
 {
+    /// <summary>
+    /// The setpoint for the PID to reach
+    /// </summary>
     [LuaProperty("sp")] public T SetPoint { get; set; }
+    /// <summary>
+    /// The proportional gain - how aggressively to respond to the current error
+    /// </summary>
     [LuaProperty("kp")] public double KP { get; set; }
+    /// <summary>
+    /// The integral gain - how aggressively to eliminate accumulated error
+    /// </summary>
     [LuaProperty("ki")] public double KI { get; set; }
+    /// <summary>
+    /// The derivative gain - how aggressively to dampen the rate of change
+    /// </summary>
     [LuaProperty("kd")] public double KD { get; set; }
+    /// <summary>
+    /// Whether to treat the PID as discrete or continuous
+    /// </summary>
     [LuaProperty("discrete")] public bool Discrete { get; set; }
+    /// <summary>
+    /// The internal Integral being influenced each step
+    /// </summary>
     [LuaProperty("integral")] public T Integral { get; set; }
+    /// <summary>
+    /// The error from the previous step
+    /// </summary>
     [LuaProperty("prev_error")] public T PreviousError { get; set; }
 
     private PID(T target, double p, double i, double d, bool discrete) { }
 
+    /// <summary>
+    /// Performs a PID control step
+    /// </summary>
+    /// <param name="value">The current value being measured</param>
+    /// <param name="dt">The time since the last step</param>
+    /// <returns>The control output</returns>
     [LuaMethod("step")]
     public Y Step(T value, double dt) => default;
+    /// <summary>
+    /// Performs a PID control step
+    /// </summary>
+    /// <param name="value">The current value being measured</param>
     [LuaMethod("step")]
     public Y Step(T value) => default;
 
+    /// <summary>
+    /// Assigns the clamps on the control output
+    /// </summary>
+    /// <param name="min">The minimum control output</param>
+    /// <param name="max">The maximum control output</param>
     [LuaMethod("clampOutput")]
     public void ClampOutput(double min, double max) => default;
+    /// <summary>
+    /// Disables the clamps on the control output
+    /// </summary>
     [LuaMethod("clampOutput")]
     public void ClampOutput() => default;
 
+    /// <summary>
+    /// Assigns the limits on the Integral
+    /// </summary>
+    /// <param name="min">The minimum integral limit</param>
+    /// <param name="max">The maximum integral limit</param>
     [LuaMethod("limitIntegral")]
     public void LimitIntegral(double min, double max) => default;
+    /// <summary>
+    /// Disables the limits on the Integral
+    /// </summary>
     [LuaMethod("limitIntegral")]
     public void LimitIntegral() => default;
 
+    /// <summary>
+    /// A Scalar PID for handling doubles
+    /// </summary>
     public class Scalar : PID<double, double> 
     {
+        /// <summary>
+        /// Constructs a new Scalar PID Controller
+        /// </summary>
+        /// <param name="target">The setpoint to reach</param>
+        /// <param name="p">The proporional gain</param>
+        /// <param name="i">The integral gain</param>
+        /// <param name="d">The derivative gain</param>
+        /// <param name="discrete">Whether the PID controller is discrete or continuous</param>
         [LuaConstructor("pid.new")]
         public Scalar(T target, double p, double i, double d, bool discrete) : base(target, p, i, d, discrete) { }
     }
+    /// <summary>
+    /// A Vector PID for handling Vectors
+    /// </summary>
     public class Vector : PID<Vector3, Vector3> 
     {
+        /// <summary>
+        /// Constructs a new Vector PID Controller
+        /// </summary>
+        /// <param name="target">The setpoint to reach</param>
+        /// <param name="p">The proporional gain</param>
+        /// <param name="i">The integral gain</param>
+        /// <param name="d">The derivative gain</param>
+        /// <param name="discrete">Whether the PID controller is discrete or continuous</param>
         [LuaConstructor("pid.new")]
         public Vector(T target, double p, double i, double d, bool discrete) : base(target, p, i, d, discrete) { }
     }
+    /// <summary>
+    /// A Quaternion PID for handling Quaternion. Step outputs the angular velocity as the control output.
+    /// </summary>
     public class Quat : PID<Quaternion, Vector3>
     {
+        /// <summary>
+        /// Constructs a new Quaternion PID Controller
+        /// </summary>
+        /// <param name="target">The setpoint to reach</param>
+        /// <param name="p">The proporional gain</param>
+        /// <param name="i">The integral gain</param>
+        /// <param name="d">The derivative gain</param>
+        /// <param name="discrete">Whether the PID controller is discrete or continuous</param>
         [LuaConstructor("pid.new")]
         public Quat(T target, double p, double i, double d, bool discrete) : base(target, p, i, d, discrete) { }
     }

--- a/src/CCSharp/AdvancedMath/PID.cs
+++ b/src/CCSharp/AdvancedMath/PID.cs
@@ -6,7 +6,7 @@ namespace CCSharp.AdvancedMath;
 /// <summary>
 /// A basic PID type and common PID operations. This may be useful when working with control systems.
 /// </summary>
-[LuaRequiredModule("AdvancedMath.pid", "pid")]
+[LuaRequireModule("AdvancedMath.pid", "pid")]
 public abstract class PID<T, Y>
 {
     /// <summary>
@@ -61,7 +61,7 @@ public abstract class PID<T, Y>
     /// <param name="min">The minimum control output</param>
     /// <param name="max">The maximum control output</param>
     [LuaMethod("clampOutput")]
-    public void ClampOutput(double min, double max) => default;
+    public void ClampOutput(double min, double max) { }
     /// <summary>
     /// Disables the clamps on the control output
     /// </summary>
@@ -74,12 +74,12 @@ public abstract class PID<T, Y>
     /// <param name="min">The minimum integral limit</param>
     /// <param name="max">The maximum integral limit</param>
     [LuaMethod("limitIntegral")]
-    public void LimitIntegral(double min, double max) => default;
+    public void LimitIntegral(double min, double max) { }
     /// <summary>
     /// Disables the limits on the Integral
     /// </summary>
     [LuaMethod("limitIntegral")]
-    public void LimitIntegral() => default;
+    public void LimitIntegral() { }
 
     /// <summary>
     /// A Scalar PID for handling doubles
@@ -95,7 +95,7 @@ public abstract class PID<T, Y>
         /// <param name="d">The derivative gain</param>
         /// <param name="discrete">Whether the PID controller is discrete or continuous</param>
         [LuaConstructor("pid.new")]
-        public Scalar(T target, double p, double i, double d, bool discrete) : base(target, p, i, d, discrete) { }
+        public Scalar(double target, double p, double i, double d, bool discrete) : base(target, p, i, d, discrete) { }
     }
     /// <summary>
     /// A Vector PID for handling Vectors
@@ -111,7 +111,7 @@ public abstract class PID<T, Y>
         /// <param name="d">The derivative gain</param>
         /// <param name="discrete">Whether the PID controller is discrete or continuous</param>
         [LuaConstructor("pid.new")]
-        public Vector(T target, double p, double i, double d, bool discrete) : base(target, p, i, d, discrete) { }
+        public Vector(Vector3 target, double p, double i, double d, bool discrete) : base(target, p, i, d, discrete) { }
     }
     /// <summary>
     /// A Quaternion PID for handling Quaternion. Step outputs the angular velocity as the control output.
@@ -127,6 +127,6 @@ public abstract class PID<T, Y>
         /// <param name="d">The derivative gain</param>
         /// <param name="discrete">Whether the PID controller is discrete or continuous</param>
         [LuaConstructor("pid.new")]
-        public Quat(T target, double p, double i, double d, bool discrete) : base(target, p, i, d, discrete) { }
+        public Quat(Quaternion target, double p, double i, double d, bool discrete) : base(target, p, i, d, discrete) { }
     }
 }

--- a/src/CCSharp/AdvancedMath/PID.cs
+++ b/src/CCSharp/AdvancedMath/PID.cs
@@ -4,7 +4,7 @@ using CCSharp.ComputerCraft;
 namespace CCSharp.AdvancedMath;
 
 [LuaRequiredModule("AdvancedMath.pid", "pid")]
-public class PID<T, Y>
+public abstract class PID<T, Y>
 {
     [LuaProperty("sp")] public T SetPoint { get; set; }
     [LuaProperty("kp")] public double KP { get; set; }

--- a/src/CCSharp/AdvancedMath/Quaternion.cs
+++ b/src/CCSharp/AdvancedMath/Quaternion.cs
@@ -28,7 +28,7 @@ public class Quaternion
     /// <param name="axis">The rotation axis that will be used for the Quaternion. The axis does not need to be normalized.</param>
     /// <param name="angle">The angle to rotate by, in radians.</param>
     [LuaMethod("quaternion.fromAxisAngle")]
-    public static Quaternion FromAxisAngle(Vector3 axis, double angle) { }
+    public static Quaternion FromAxisAngle(Vector3 axis, double angle) => default;
 
     /// <summary>
     /// Constructs a new quaternion using the provided pitch, yaw and roll. Uses the YXZ reference frame

--- a/src/CCSharp/AdvancedMath/Quaternion.cs
+++ b/src/CCSharp/AdvancedMath/Quaternion.cs
@@ -1,0 +1,158 @@
+using CCSharp.Attributes;
+using CCSharp.ComputerCraft;
+
+namespace CCSharp.AdvancedMath;
+
+/// <summary>
+/// A basic quaternion type and some common quaternion operations. This may be useful when working with rotation in regards to physics (such as those from the Ship API provided by CC: VS).
+/// </summary>
+public class Quaternion
+{
+    [LuaProperty("vec")]
+    public Vector3 Imaginary { get; set; }
+    [LuaProperty("a")]
+    public double Real { get; set; }
+
+    /// <summary>
+    /// Constructs a new Quaternion from a Vector and a w parameter. Similarly to fromComponents, this method will not produce a normalized Quaternion.
+    /// </summary>
+    /// <param name="vec">The imaginary component of the Vector, stored in a Vector.</param>
+    /// <param name="w">The real component of the Quaternion.</param>
+    [LuaConstructor("quaternion.new")]
+    public Quaternion(Vector3 vec, double w) { }
+
+    /// <summary>
+    /// Constructs a new Quaternion from the provided axis - angle parameters. The resulting Quaternion is already normalized.
+    /// </summary>
+    /// <param name="axis">The rotation axis that will be used for the Quaternion. The axis does not need to be normalized.</param>
+    /// <param name="angle">The angle to rotate by, in radians.</param>
+    [LuaConstructor("quaternion.fromAxisAngle")]
+    public Quaternion(Vector3 axis, double angle) { }
+
+    /// <summary>
+    /// Constructs a new quaternion using the provided pitch, yaw and roll. Uses the YXZ reference frame
+    /// </summary>
+    /// <param name="pitch">The pitch in radians.</param>
+    /// <param name="yaw">The yaw in radians.</param>
+    /// <param name="roll">The roll in radians.</param>
+    [LuaConstructor("quaternion.fromEuler")]
+    public Quaternion(double pitch, double yaw, double roll) { }
+
+    /// <summary>
+    /// Constructs a new Quaternion from its components. Note that this will not produce a normalized Quaternion.
+    /// </summary>
+    /// <param name="x">The X component of the imaginary part.</param>
+    /// <param name="y">The Y component of the imaginary part.</param>
+    /// <param name="z">The Z component of the imaginary part.</param>
+    /// <param name="w">The real component of the Quaternion.</param>
+    [LuaConstructor("quaternion.fromComponents")]
+    public Quaternion(double x, double y, double z, double w) { }
+
+    /// <summary>
+    /// Constructs a new quaternion from a 3x3 rotation matrix or 4x4 transformation matrix.
+    /// </summary>
+    /// <param name="matrix">The rotation matrix to convert to a Quaternion.</param>
+    [LuaConstructor("quaternion.fromMatrix")]
+    public Quaternion(Matrix matrix) { }
+
+    /// <summary>
+    /// Constructs a new identity Quaternion (0, 0, 0, 1).
+    /// </summary>
+    [LuaConstructor("quaternion.identity")]
+    public Quaternion() { }
+
+    /// <summary>
+    /// Get the length (also referred to as magnitude) of this Quaternion.
+    /// </summary>
+    /// <returns>The length of this quaternion.</returns>
+    [LuaMethod("length")]
+    public double Length() => default;
+
+    /// <summary>
+    /// Finds the conjugate of the Quaternion.
+    /// </summary>
+    /// <returns>The conjugated Quaternion.</returns>
+    [LuaMethod("conjugate")]
+    public Quaternion Conjugate() => default;
+
+    /// <summary>
+    /// Normalizes the Quaternion, producing a unit Quaternion with the same direction.
+    /// </summary>
+    /// <returns>The normalized Quaternion.</returns>
+    [LuaMethod("normalize")]
+    public Quaternion Normalize() => default;
+
+    /// <summary>
+    /// Inverts the Quaternion.
+    /// </summary>
+    /// <returns>The inverted Quaternion.</returns>
+    [LuaMethod("inverse")]
+    public Quaternion Inverse() => default;
+
+    /// <summary>
+    /// Performs spherical linear interpolation between this Quaternion and another Quaternion.
+    /// </summary>
+    /// <param name="b">The target Quaternion to interpolate towards.</param>
+    /// <param name="alpha">The interpolation factor, between 0 and 1.</param>
+    /// <returns>The interpolated Quaternion.</returns>
+    [LuaMethod("slerp")]
+    public Quaternion Slerp(Quaternion b, double alpha) => default;
+
+    /// <summary>
+    /// Gets the angle of rotation represented by this Quaternion, in radians.
+    /// </summary>
+    /// <returns>The angle of rotation in radians.</returns>
+    [LuaMethod("getAngle")]
+    public double GetAngle() => default;
+
+    /// <summary>
+    /// Gets the axis of rotation represented by this Quaternion.
+    /// </summary>
+    /// <returns>The axis of rotation as a Vector3.</returns>
+    [LuaMethod("getAxis")]
+    public Vector3 GetAxis() => default;
+
+    /// <summary>
+    /// Converts this Quaternion to pitch, yaw and roll angles, using the YXZ reference frame
+    /// </summary>
+    /// <returns>A tuple containing the pitch, yaw and roll in radians.</returns>
+    [LuaMethod("toEuler", CallMethodFlags.WrapAsTable)]
+    public (double pitch, double yaw, double roll) ToEuler() => default;
+
+    /// <summary>
+    /// Converts this Quaternion to a 3x3 rotation matrix.
+    /// </summary>
+    /// <returns>The rotation matrix.</returns>
+    [LuaMethod("toMatrix")]
+    public Matrix ToMatrix() => default;
+
+    /// <summary>
+    /// Checks if any component of this Quaternion is NaN.
+    /// </summary>
+    /// <returns>True if any component is NaN, false otherwise.</returns>
+    [LuaMethod("isNan")]
+    public bool IsNaN() => default;
+
+    /// <summary>
+    /// Checks if any component of this Quaternion is infinite.
+    /// </summary>
+    /// <returns>True if any component is infinite, false otherwise.</returns>
+    [LuaMethod("isInf")]
+    public bool IsInfinite() => default;
+
+    /// <summary>
+    /// Creates a copy of this Quaternion.
+    /// </summary>
+    /// <returns>The copied Quaternion.</returns>
+    [LuaMethod("copy")]
+    public Quaternion Copy() => default;
+
+    public static Quaternion operator +(Quaternion a, Quaternion b) => default;
+    public static Quaternion operator -(Quaternion a, Quaternion b) => default;
+    public static Quaternion operator *(Quaternion a, Quaternion b) => default;
+    public static Vector3 operator *(Quaternion q, Vector3 s) => default;
+    public static Quaternion operator *(Quaternion q, double s) => default;
+    public static Quaternion operator /(Quaternion q, Quaternion s) => default;
+    public static Quaternion operator /(Quaternion q, double s) => default;
+    public static Quaternion operator -(Quaternion q) => default;
+}

--- a/src/CCSharp/AdvancedMath/Quaternion.cs
+++ b/src/CCSharp/AdvancedMath/Quaternion.cs
@@ -27,8 +27,8 @@ public class Quaternion
     /// </summary>
     /// <param name="axis">The rotation axis that will be used for the Quaternion. The axis does not need to be normalized.</param>
     /// <param name="angle">The angle to rotate by, in radians.</param>
-    [LuaConstructor("quaternion.fromAxisAngle")]
-    public Quaternion(Vector3 axis, double angle) { }
+    [LuaMethod("quaternion.fromAxisAngle")]
+    public static Quaternion FromAxisAngle(Vector3 axis, double angle) { }
 
     /// <summary>
     /// Constructs a new quaternion using the provided pitch, yaw and roll. Uses the YXZ reference frame

--- a/src/CCSharp/AdvancedMath/Quaternion.cs
+++ b/src/CCSharp/AdvancedMath/Quaternion.cs
@@ -1,5 +1,6 @@
 using CCSharp.Attributes;
 using CCSharp.ComputerCraft;
+using CCSharp.RedIL.Resolving.CommonResolvers;
 
 namespace CCSharp.AdvancedMath;
 

--- a/src/CCSharp/CCVS/Ship.cs
+++ b/src/CCSharp/CCVS/Ship.cs
@@ -1,6 +1,7 @@
 using CCSharp.Attributes;
 using CCSharp.ComputerCraft;
 using CCSharp.AdvancedMath;
+using System.Collections.Generic;
 
 namespace CCSharp.CCVS;
 /// <summary>
@@ -13,7 +14,7 @@ public class Ship
     /// </summary>
     /// <returns>The Ship's unique ID</returns>
     [LuaMethod("ship.getId")]
-    public static Long GetId() => default;
+    public static long GetId() => default;
 
     /// <summary>
     /// Gets the Ship's unique Slug
@@ -55,7 +56,7 @@ public class Ship
     /// </summary>
     /// <returns>A dictionary of all Constraints and their respective IDs</returns>
     [LuaMethod("ship.getConstraints")]
-    public static Dictionary<Long, Constraint> GetConstraints() => default;
+    public static Dictionary<long, Constraint> GetConstraints() => default;
 
     /// <summary>
     /// Gets the Ship's Center of Mass in the Shipyard
@@ -145,7 +146,7 @@ public class Ship
     /// <summary>
     /// Contains the output data from "physics_ticks" regarding the individual tick
     /// </summary>
-    class PhysicsTick
+    public class PhysicsTick
     {
         /// <summary>
         /// Gets the buoyant factor during this physics tick
@@ -192,7 +193,7 @@ public class Ship
         /// <summary>
         /// The inertia data provided by the physics tick
         /// </summary>
-        class Inertia
+        public class Inertia
         {
             [LuaProperty("momentOfInertiaTensor")] public Matrix MomentOfInertiaTensor { get; set; }
             [LuaProperty("mass")] public double Mass { get; set; }
@@ -201,7 +202,7 @@ public class Ship
         /// <summary>
         /// The pose vel data provided by the physics tick
         /// </summary>
-        class PoseVel
+        public class PoseVel
         {
             [LuaProperty("vel")] public Vector3 LinearVelocity { get; set; }
             [LuaProperty("omega")] public Vector3 AngularVelocity { get; set; }
@@ -320,7 +321,7 @@ public class Ship
     /// The base constraint data class
     /// </summary>
     [LuaTableTypeCheck(TableAccessor = "type")]
-    class Constraint
+    public class Constraint
     {
         [LuaEnum(typeof(ConstraintType))]
         public enum ConstraintType
@@ -339,8 +340,8 @@ public class Ship
             [LuaEnumValue("spherical_twist_limits")] SphericalTwistLimits
         }
 
-        [LuaProperty("shipId0")] public Long FirstShipID { get; set; }
-        [LuaProperty("shipId1")] public Long SecondShipID { get; set; }
+        [LuaProperty("shipId0")] public long FirstShipID { get; set; }
+        [LuaProperty("shipId1")] public long SecondShipID { get; set; }
         [LuaProperty("type")] public ConstraintType Type { get; set; }
         [LuaProperty("compliance")] public double Compliance { get; set; }
     }
@@ -349,7 +350,7 @@ public class Ship
     /// The attachment constraint data class
     /// </summary>
     [LuaImplicitTypeArgument("attachment")]
-    class AttachmentConstraint : Constraint
+    public class AttachmentConstraint : Constraint
     {
         [LuaProperty("localPos0")] public Vector3 FirstPosition { get; set; }
         [LuaProperty("localPos1")] public Vector3 SecondPosition { get; set; }
@@ -362,7 +363,7 @@ public class Ship
     /// The hinge swing limits constraint data class
     /// </summary>
     [LuaImplicitTypeArgument("hinge_swing_limits")]
-    class HingeSwingLimitsConstraint : Constraint
+    public class HingeSwingLimitsConstraint : Constraint
     {
         [LuaProperty("localRot0")] public Quaternion FirstPosition { get; set; }
         [LuaProperty("localRot1")] public Quaternion SecondPosition { get; set; }
@@ -376,7 +377,7 @@ public class Ship
     /// The hinge target angle constraint data class
     /// </summary>
     [LuaImplicitTypeArgument("thinge_target_angle")]
-    class HingeTargetAngleConstraint : Constraint
+    public class HingeTargetAngleConstraint : Constraint
     {
         [LuaProperty("localRot0")] public Quaternion FirstPosition { get; set; }
         [LuaProperty("localRot1")] public Quaternion SecondPosition { get; set; }
@@ -390,7 +391,7 @@ public class Ship
     /// The position damping constraint data class
     /// </summary>
     [LuaImplicitTypeArgument("pos_damping")]
-    class PosDampingConstraint : Constraint
+    public class PosDampingConstraint : Constraint
     {
         [LuaProperty("localPos0")] public Vector3 FirstPosition { get; set; }
         [LuaProperty("localPos1")] public Vector3 SecondPosition { get; set; }
@@ -402,7 +403,7 @@ public class Ship
     /// The rope constraint data class
     /// </summary>
     [LuaImplicitTypeArgument("rope")]
-    class RopeConstraint : Constraint
+    public class RopeConstraint : Constraint
     {
         [LuaProperty("localPos0")] public Vector3 FirstPosition { get; set; }
         [LuaProperty("localPos1")] public Vector3 SecondPosition { get; set; }
@@ -415,7 +416,7 @@ public class Ship
     /// The rotation damping constraint data class
     /// </summary>
     [LuaImplicitTypeArgument("rot_damping")]
-    class RotDampingConstraint : Constraint
+    public class RotDampingConstraint : Constraint
     {
         [LuaEnum(typeof(RotDampingAxes))]
         public enum RotDampingAxes
@@ -436,7 +437,7 @@ public class Ship
     /// The slide constraint data class
     /// </summary>
     [LuaImplicitTypeArgument("slide")]
-    class SlideConstraint : Constraint
+    public class SlideConstraint : Constraint
     {
         [LuaProperty("localPos0")] public Vector3 FirstPosition { get; set; }
         [LuaProperty("localPos1")] public Vector3 SecondPosition { get; set; }
@@ -449,7 +450,7 @@ public class Ship
     /// The spherical swing limits constraint data class
     /// </summary>
     [LuaImplicitTypeArgument("spherical_swing_limits")]
-    class SphericalSwingLimitsConstraint : Constraint
+    public class SphericalSwingLimitsConstraint : Constraint
     {
         [LuaProperty("localRot0")] public Quaternion FirstPosition { get; set; }
         [LuaProperty("localRot1")] public Quaternion SecondPosition { get; set; }
@@ -462,7 +463,7 @@ public class Ship
     /// The spherical twist limits constraint data class
     /// </summary>
     [LuaImplicitTypeArgument("spherical_twist_limits")]
-    class SphericalTwistLimitsConstraint : Constraint
+    public class SphericalTwistLimitsConstraint : Constraint
     {
         [LuaProperty("localRot0")] public Quaternion FirstPosition { get; set; }
         [LuaProperty("localRot1")] public Quaternion SecondPosition { get; set; }

--- a/src/CCSharp/CCVS/Ship.cs
+++ b/src/CCSharp/CCVS/Ship.cs
@@ -46,9 +46,9 @@ public class Ship
     /// <summary>
     /// Converts the Ship to and from a static object
     /// </summary>
-    /// <param name="static">Whether the Ship should be static</returns>
+    /// <param name="s">Whether the Ship should be static</returns>
     [LuaMethod("ship.setStatic")]
-    public static void SetStatic(bool static) { }
+    public static void SetStatic(bool s) { }
 
     /// <summary>
     /// Gets all Constraints affecting the Ship

--- a/src/CCSharp/CCVS/Ship.cs
+++ b/src/CCSharp/CCVS/Ship.cs
@@ -3,90 +3,204 @@ using CCSharp.ComputerCraft;
 using CCSharp.AdvancedMath;
 
 namespace CCSharp.CCVS;
-
+/// <summary>
+/// This API is added by CC: VS and allows CCSharp to access information from Valkyrien Skies Ships.
+/// </summary>
 public class Ship
 {
+    /// <summary>
+    /// Gets the Ship's unique ID
+    /// </summary>
+    /// <returns>The Ship's unique ID</returns>
     [LuaMethod("ship.getId")]
     public static Long GetId() => default;
 
+    /// <summary>
+    /// Gets the Ship's unique Slug
+    /// </summary>
+    /// <returns>The Ship's unique Slug</returns>
     [LuaMethod("ship.getSlug")]
     public static string GetSlug() => default;
 
+    /// <summary>
+    /// Sets the Ship's Slug
+    /// </summary>
+    /// <param name="slug">The new Slug</returns>
     [LuaMethod("ship.setSlug")]
     public static void SetSlug(string slug) => default;
 
+    /// <summary>
+    /// Gets the Ship's Mass
+    /// </summary>
+    /// <returns>The Ship's Mass</returns>
     [LuaMethod("ship.getMass")]
     public static double GetMass() => default;
 
+    /// <summary>
+    /// Determines whether the Ship is a static or dynamic object
+    /// </summary>
+    /// <returns>True if the Ship is a static object, otherwise false</returns>
     [LuaMethod("ship.isStatic")]
     public static bool IsStatic() => default;
 
+    /// <summary>
+    /// Converts the Ship to and from a static object
+    /// </summary>
+    /// <param name="static">Whether the Ship should be static</returns>
+    [LuaMethod("ship.setStatic")]
+    public static bool SetStatic(bool static) => default;
+
+    /// <summary>
+    /// Gets all Constraints affecting the Ship
+    /// </summary>
+    /// <returns>A dictionary of all Constraints and their respective IDs</returns>
     [LuaMethod("ship.getConstraints")]
     public static Dictionary<Long, Constraint> GetConstraints() => default;
 
+    /// <summary>
+    /// Gets the Ship's Center of Mass in the Shipyard
+    /// </summary>
+    /// <returns>The Ship's Center of Mass in the Shipyard</returns>
     [LuaMethod("ship.getShipyardPosition")]
     public static Vector3 GetShipyardPosition() => default;
 
+    /// <summary>
+    /// Gets the Ship's Center of Mass in Worldspace
+    /// </summary>
+    /// <returns>The Ship's Center of Mass in Worldspace</returns>
     [LuaMethod("ship.getWorldspacePosition")]
     public static Vector3 GetWorldspacePosition() => default;
 
+    /// <summary>
+    /// Gets the Ship's linear velocity
+    /// </summary>
+    /// <returns>The Ship's linear velocity</returns>
     [LuaMethod("ship.getVelocity")]
     public static Vector3 GetLinearVelocity() => default;
 
+    /// <summary>
+    /// Gets the Ship's angular velocity
+    /// </summary>
+    /// <returns>The Ship's angular velocity</returns>
     [LuaMethod("ship.getOmega")]
     public static Vector3 GetAngularVelocity() => default;
 
+    /// <summary>
+    /// Gets the Ship's scale. Note that, despite returning a Vector, the scale is uniform.
+    /// </summary>
+    /// <returns>The Ship's scale</returns>
     [LuaMethod("ship.getScale")]
     public static Vector3 GetScale() => default;
 
+    /// <summary>
+    /// Sets the Ship's scale
+    /// </summary>
+    /// <param name="scale">The new scale of the Ship</param>
     [LuaMethod("ship.setScale")]
     public static void SetScale(double scale) => default;
 
+    /// <summary>
+    /// Gets the Ship's orientation as a Quaternion
+    /// </summary>
+    /// <returns>The Ship's Quaternion</returns>
     [LuaMethod("ship.getQuaternion")]
     public static Quaternion GetQuaternion() => default;
 
+    /// <summary>
+    /// Gets the Ship's transformation matrix
+    /// </summary>
+    /// <returns>The Ship's transformation matrix</returns>
     [LuaMethod("ship.getTransformationMatrix")]
     public static Matrix GetTransformationMatrix() => default;
 
+    /// <summary>
+    /// Gets the Ship's current Moment of Inertia Tensor as a Matrix
+    /// </summary>
+    /// <returns>The Ship's current Moment of Inertia Tensor</returns>
     [LuaMethod("ship.getMomentOfInertiaTensorToSave")]
     public static Matrix GetMomentOfInertiaTensorToSave() => default;
 
+    /// <summary>
+    /// Gets the Ship's previous Moment of Inertia Tensor as a Matrix
+    /// </summary>
+    /// <returns>The Ship's previous Moment of Inertia Tensor</returns>
     [LuaMethod("ship.getMomentOfInertiaTensor")]
     public static Matrix GetMomentOfInertiaTensor() => default;
 
+    /// <summary>
+    /// Transform the given Shipyard position to Worldspace if it is on the same Ship
+    /// </summary>
+    /// <param name="pos">The Shipyard position on the Ship</param>
+    /// <returns>The Worldspace position</returns>
     [LuaMethod("ship.transformPositionToWorld")]
     public static Vector3 transformPositionToWorld(Vector3 pos) => default;
 
+    /// <summary>
+    /// Holds the thread while awaiting the "physics_ticks" event
+    /// </summary>
+    /// <returns>The event name and PhysicsTick for every previous physics tick since last gametick</returns>
     [LuaMethod("ship.pullPhysicsTicks")]
     public static (string name, PhysicsTick[] ticks) PullPhysicsTicks() => default;
 
-    [LuaTableTypeCheck(TableAccessor = "getBuoyantFactor"), LuaTableTypeCheck(TableAccessor = "isStatic"), LuaTableTypeCheck(TableAccessor = "doFluidDrag"), LuaTableTypeCheck(TableAccessor = "getInertia"), LuaTableTypeCheck(TableAccessor = "getPoseVel"), LuaTableTypeCheck(TableAccessor = "getForceInducers")]
+    /// <summary>
+    /// Contains the output data from "physics_ticks" regarding the individual tick
+    /// </summary>
     class PhysicsTick
     {
+        /// <summary>
+        /// Gets the buoyant factor during this physics tick
+        /// </summary>
+        /// <returns>The Ship's buoyant factor</returns>
         [LuaMethod("getBuoyantFactor")]
         public double GetBuoyantFactor() => default;
 
+        /// <summary>
+        /// Determines whether the Ship was static or dynamic during this physics tick
+        /// </summary>
+        /// <returns>True if it was static dyuring this physics tick, otherwise false</returns>
         [LuaMethod("isStatic")]
         public bool IsStatic() => default;
 
+        /// <summary>
+        /// Determines whether the Ship was affected by fluid drag during this physics tick
+        /// </summary>
+        /// <returns>True if it was affected by fluid drag during this physics tick</returns>
         [LuaMethod("doFluidDrag")]
         public bool FluidDrag() => default;
 
+        /// <summary>
+        /// Gets the inertia data during this physics tick
+        /// </summary>
+        /// <returns>The Ship's inertia data during this physics tick</returns>
         [LuaMethod("getInertia")]
         public Inertia GetInertia() => default;
 
+        /// <summary>
+        /// Gets the pose vel data during this physics tick
+        /// </summary>
+        /// <returns>The Ship's pose vel data during this physics tick</returns>
         [LuaMethod("getPoseVel")]
         public PoseVel GetPoseVel() => default;
 
+        /// <summary>
+        /// Gets the force inducers acting on the Ship during this physics tick
+        /// </summary>
+        /// <returns>The Ship's force inducers during this physics tick</returns>
         [LuaMethod("getForceInducers")]
         public string[] GetForceInducers() => default;
 
+        /// <summary>
+        /// The inertia data provided by the physics tick
+        /// </summary>
         class Inertia
         {
             [LuaProperty("momentOfInertiaTensor")] public Matrix MomentOfInertiaTensor { get; set; }
             [LuaProperty("mass")] public double Mass { get; set; }
         }
 
+        /// <summary>
+        /// The pose vel data provided by the physics tick
+        /// </summary>
         class PoseVel
         {
             [LuaProperty("vel")] public Vector3 LinearVelocity { get; set; }
@@ -97,39 +211,114 @@ public class Ship
 
     }
 
+    /// <summary>
+    /// Teleports the Ship using the input data. Highly recommend not using.
+    /// </summary>
+    /// <param name="data">The data to use during teleportation</param>
     [LuaMethod("ship.teleport")]
     public static void Teleport(object data) => default;
 
+    /// <summary>
+    /// Applies an invariant force to the Ship on the next physics tick
+    /// </summary>
+    /// <param name="force">The force to be applied</param>
     [LuaMethod("ship.applyInvariantForce")]
     public static void ApplyInvariantForce(Vector3 force) => default;
+    /// <summary>
+    /// Applies an invariant force to the Ship on the next physics tick
+    /// </summary>
+    /// <param name="forceX">The force to be applied on the X axis</param>
+    /// <param name="forceY">The force to be applied on the Y axis</param>
+    /// <param name="forceZ">The force to be applied on the Z axis</param>
     [LuaMethod("ship.applyInvariantForce")]
     public static void ApplyInvariantForce(double forceX, double forceY, double forceZ) => default;
 
+    /// <summary>
+    /// Applies an invariant torque to the Ship on the next physics tick
+    /// </summary>
+    /// <param name="torque">The torque to be applied</param>
     [LuaMethod("ship.applyInvariantTorque")]
     public static void ApplyInvariantTorque(Vector3 torque) => default;
+    /// <summary>
+    /// Applies an invariant torque to the Ship on the next physics tick
+    /// </summary>
+    /// <param name="torqueX">The torque to be applied on the X axis</param>
+    /// <param name="torqueY">The torque to be applied on the Y axis</param>
+    /// <param name="torqueZ">The torque to be applied on the Z axis</param>
     [LuaMethod("ship.applyInvariantTorque")]
     public static void ApplyInvariantTorque(double torqueX, double torqueY, double torqueZ) => default;
 
+    /// <summary>
+    /// Applies an invariant force to the Ship at the given local offset on the next physics tick
+    /// </summary>
+    /// <param name="force">The force to be applied</param>
+    /// <param name="pos">The local offset ot apply the force to</param>
     [LuaMethod("ship.applyInvariantForceToPos")]
     public static void ApplyInvariantForceToPosition(Vector3 force, Vector3 pos) => default;
+    /// <summary>
+    /// Applies an invariant force to the Ship at the given local offset on the next physics tick
+    /// </summary>
+    /// <param name="forceX">The force to be applied on the X axis</param>
+    /// <param name="forceY">The force to be applied on the Y axis</param>
+    /// <param name="forceZ">The force to be applied on the Z axis</param>
+    /// <param name="posX">The local X-axis offset to apply the force to</param>
+    /// <param name="posY">The local Y-axis offset to apply the force to</param>
+    /// <param name="posZ">The local Z-axis offset to apply the force to</param>
     [LuaMethod("ship.applyInvariantForceToPos")]
     public static void ApplyInvariantForceToPosition(double forceX, double forceY, double forceZ, double posX, double posY, double posZ) => default;
 
+    /// <summary>
+    /// Applies a rotation-dependent force to the Ship on the next physics tick
+    /// </summary>
+    /// <param name="force">The force to be applied</param>
     [LuaMethod("ship.applyRotDependentForce")]
     public static void ApplyRotDependentForce(Vector3 force) => default;
+    /// <summary>
+    /// Applies a rotation-dependent force to the Ship on the next physics tick
+    /// </summary>
+    /// <param name="forceX">The force to be applied on the X axis</param>
+    /// <param name="forceY">The force to be applied on the Y axis</param>
+    /// <param name="forceZ">The force to be applied on the Z axis</param>
     [LuaMethod("ship.applyRotDependentForce")]
     public static void ApplyRotDependentForce(double forceX, double forceY, double forceZ) => default;
 
+    /// <summary>
+    /// Applies a rotation-dependent torque to the Ship on the next physics tick
+    /// </summary>
+    /// <param name="torque">The torque to be applied</param>
     [LuaMethod("ship.applyRotDependentTorque")]
     public static void ApplyRotDependentTorque(Vector3 torque) => default;
+    /// <summary>
+    /// Applies a rotation-dependent torque to the Ship on the next physics tick
+    /// </summary>
+    /// <param name="torqueX">The torque to be applied on the X axis</param>
+    /// <param name="torqueY">The torque to be applied on the Y axis</param>
+    /// <param name="torqueZ">The torque to be applied on the Z axis</param>
     [LuaMethod("ship.applyRotDependentTorque")]
     public static void ApplyRotDependentTorque(double torqueX, double torqueY, double torqueZ) => default;
 
+    /// <summary>
+    /// Applies a rotation-dependent force to the Ship at the given local offset on the next physics tick
+    /// </summary>
+    /// <param name="force">The force to be applied</param>
+    /// <param name="pos">The local offset ot apply the force to</param>
     [LuaMethod("ship.applyRotDependentForceToPos")]
     public static void ApplyRotDependentForceToPosition(Vector3 force, Vector3 pos) => default;
+    /// <summary>
+    /// Applies a rotation-dependent force to the Ship at the given local offset on the next physics tick
+    /// </summary>
+    /// <param name="forceX">The force to be applied on the X axis</param>
+    /// <param name="forceY">The force to be applied on the Y axis</param>
+    /// <param name="forceZ">The force to be applied on the Z axis</param>
+    /// <param name="posX">The local X-axis offset to apply the force to</param>
+    /// <param name="posY">The local Y-axis offset to apply the force to</param>
+    /// <param name="posZ">The local Z-axis offset to apply the force to</param>
     [LuaMethod("ship.applyRotDependentForceToPos")]
     public static void ApplyRotDependentForceToPosition(double forceX, double forceY, double forceZ, double posX, double posY, double posZ) => default;
 
+    /// <summary>
+    /// The base constraint data class
+    /// </summary>
     [LuaTableTypeCheck(TableAccessor = "type")]
     class Constraint
     {
@@ -156,7 +345,10 @@ public class Ship
         [LuaProperty("compliance")] public double Compliance { get; set; }
     }
 
-    [LuaImplicitTypeArgument("type")]
+    /// <summary>
+    /// The attachment constraint data class
+    /// </summary>
+    [LuaImplicitTypeArgument("attachment")]
     class AttachmentConstraint : Constraint
     {
         [LuaProperty("localPos0")] public Vector3 FirstPosition { get; set; }
@@ -165,7 +357,11 @@ public class Ship
         [LuaProperty("fixedDistance")] public double FixedDistance { get; set; }
     }
 
-    [LuaImplicitTypeArgument("type")]
+
+    /// <summary>
+    /// The hinge swing limits constraint data class
+    /// </summary>
+    [LuaImplicitTypeArgument("hinge_swing_limits")]
     class HingeSwingLimitsConstraint : Constraint
     {
         [LuaProperty("localRot0")] public Quaternion FirstPosition { get; set; }
@@ -175,7 +371,11 @@ public class Ship
         [LuaProperty("maxSwingAngle")] public double MaxSwingAngle { get; set; }
     }
 
-    [LuaImplicitTypeArgument("type")]
+
+    /// <summary>
+    /// The hinge target angle constraint data class
+    /// </summary>
+    [LuaImplicitTypeArgument("thinge_target_angle")]
     class HingeTargetAngleConstraint : Constraint
     {
         [LuaProperty("localRot0")] public Quaternion FirstPosition { get; set; }
@@ -185,7 +385,11 @@ public class Ship
         [LuaProperty("nextTickTargetAngle")] public double NextTickTargetAngle { get; set; }
     }
 
-    [LuaImplicitTypeArgument("type")]
+
+    /// <summary>
+    /// The position damping constraint data class
+    /// </summary>
+    [LuaImplicitTypeArgument("pos_damping")]
     class PosDampingConstraint : Constraint
     {
         [LuaProperty("localPos0")] public Vector3 FirstPosition { get; set; }
@@ -194,7 +398,10 @@ public class Ship
         [LuaProperty("posDamping")] public double PosDamping { get; set; }
     }
 
-    [LuaImplicitTypeArgument("type")]
+    /// <summary>
+    /// The rope constraint data class
+    /// </summary>
+    [LuaImplicitTypeArgument("rope")]
     class RopeConstraint : Constraint
     {
         [LuaProperty("localPos0")] public Vector3 FirstPosition { get; set; }
@@ -203,7 +410,11 @@ public class Ship
         [LuaProperty("ropeLength")] public double RopeLength { get; set; }
     }
 
-    [LuaImplicitTypeArgument("type")]
+
+    /// <summary>
+    /// The rotation damping constraint data class
+    /// </summary>
+    [LuaImplicitTypeArgument("rot_damping")]
     class RotDampingConstraint : Constraint
     {
         [LuaEnum(typeof(RotDampingAxes))]
@@ -221,8 +432,11 @@ public class Ship
         [LuaProperty("rotDampingAxes")] public RotDampingAxes RotDampingAxis { get; set; }
     }
 
-    [LuaImplicitTypeArgument("type")]
-    class RotDampingConstraint : Constraint
+    /// <summary>
+    /// The slide constraint data class
+    /// </summary>
+    [LuaImplicitTypeArgument("slide")]
+    class SlideConstraint : Constraint
     {
         [LuaProperty("localPos0")] public Vector3 FirstPosition { get; set; }
         [LuaProperty("localPos1")] public Vector3 SecondPosition { get; set; }
@@ -231,7 +445,10 @@ public class Ship
         [LuaProperty("maxDistBetweenPoints")] public double MaxDistanceBetweenPoints { get; set; }
     }
 
-    [LuaImplicitTypeArgument("type")]
+    /// <summary>
+    /// The spherical swing limits constraint data class
+    /// </summary>
+    [LuaImplicitTypeArgument("spherical_swing_limits")]
     class SphericalSwingLimitsConstraint : Constraint
     {
         [LuaProperty("localRot0")] public Quaternion FirstPosition { get; set; }
@@ -241,7 +458,10 @@ public class Ship
         [LuaProperty("maxSwingAngle")] public double MaxSwingAngle { get; set; }
     }
 
-    [LuaImplicitTypeArgument("type")]
+    /// <summary>
+    /// The spherical twist limits constraint data class
+    /// </summary>
+    [LuaImplicitTypeArgument("spherical_twist_limits")]
     class SphericalTwistLimitsConstraint : Constraint
     {
         [LuaProperty("localRot0")] public Quaternion FirstPosition { get; set; }

--- a/src/CCSharp/CCVS/Ship.cs
+++ b/src/CCSharp/CCVS/Ship.cs
@@ -27,7 +27,7 @@ public class Ship
     /// </summary>
     /// <param name="slug">The new Slug</returns>
     [LuaMethod("ship.setSlug")]
-    public static void SetSlug(string slug) => default;
+    public static void SetSlug(string slug) { }
 
     /// <summary>
     /// Gets the Ship's Mass
@@ -97,7 +97,7 @@ public class Ship
     /// </summary>
     /// <param name="scale">The new scale of the Ship</param>
     [LuaMethod("ship.setScale")]
-    public static void SetScale(double scale) => default;
+    public static void SetScale(double scale) { }
 
     /// <summary>
     /// Gets the Ship's orientation as a Quaternion
@@ -216,14 +216,14 @@ public class Ship
     /// </summary>
     /// <param name="data">The data to use during teleportation</param>
     [LuaMethod("ship.teleport")]
-    public static void Teleport(object data) => default;
+    public static void Teleport(object data) { }
 
     /// <summary>
     /// Applies an invariant force to the Ship on the next physics tick
     /// </summary>
     /// <param name="force">The force to be applied</param>
     [LuaMethod("ship.applyInvariantForce")]
-    public static void ApplyInvariantForce(Vector3 force) => default;
+    public static void ApplyInvariantForce(Vector3 force) { }
     /// <summary>
     /// Applies an invariant force to the Ship on the next physics tick
     /// </summary>
@@ -231,14 +231,14 @@ public class Ship
     /// <param name="forceY">The force to be applied on the Y axis</param>
     /// <param name="forceZ">The force to be applied on the Z axis</param>
     [LuaMethod("ship.applyInvariantForce")]
-    public static void ApplyInvariantForce(double forceX, double forceY, double forceZ) => default;
+    public static void ApplyInvariantForce(double forceX, double forceY, double forceZ) { }
 
     /// <summary>
     /// Applies an invariant torque to the Ship on the next physics tick
     /// </summary>
     /// <param name="torque">The torque to be applied</param>
     [LuaMethod("ship.applyInvariantTorque")]
-    public static void ApplyInvariantTorque(Vector3 torque) => default;
+    public static void ApplyInvariantTorque(Vector3 torque) { }
     /// <summary>
     /// Applies an invariant torque to the Ship on the next physics tick
     /// </summary>
@@ -246,7 +246,7 @@ public class Ship
     /// <param name="torqueY">The torque to be applied on the Y axis</param>
     /// <param name="torqueZ">The torque to be applied on the Z axis</param>
     [LuaMethod("ship.applyInvariantTorque")]
-    public static void ApplyInvariantTorque(double torqueX, double torqueY, double torqueZ) => default;
+    public static void ApplyInvariantTorque(double torqueX, double torqueY, double torqueZ) { }
 
     /// <summary>
     /// Applies an invariant force to the Ship at the given local offset on the next physics tick
@@ -254,7 +254,7 @@ public class Ship
     /// <param name="force">The force to be applied</param>
     /// <param name="pos">The local offset ot apply the force to</param>
     [LuaMethod("ship.applyInvariantForceToPos")]
-    public static void ApplyInvariantForceToPosition(Vector3 force, Vector3 pos) => default;
+    public static void ApplyInvariantForceToPosition(Vector3 force, Vector3 pos) { }
     /// <summary>
     /// Applies an invariant force to the Ship at the given local offset on the next physics tick
     /// </summary>
@@ -265,14 +265,14 @@ public class Ship
     /// <param name="posY">The local Y-axis offset to apply the force to</param>
     /// <param name="posZ">The local Z-axis offset to apply the force to</param>
     [LuaMethod("ship.applyInvariantForceToPos")]
-    public static void ApplyInvariantForceToPosition(double forceX, double forceY, double forceZ, double posX, double posY, double posZ) => default;
+    public static void ApplyInvariantForceToPosition(double forceX, double forceY, double forceZ, double posX, double posY, double posZ) { }
 
     /// <summary>
     /// Applies a rotation-dependent force to the Ship on the next physics tick
     /// </summary>
     /// <param name="force">The force to be applied</param>
     [LuaMethod("ship.applyRotDependentForce")]
-    public static void ApplyRotDependentForce(Vector3 force) => default;
+    public static void ApplyRotDependentForce(Vector3 force) { }
     /// <summary>
     /// Applies a rotation-dependent force to the Ship on the next physics tick
     /// </summary>
@@ -280,14 +280,14 @@ public class Ship
     /// <param name="forceY">The force to be applied on the Y axis</param>
     /// <param name="forceZ">The force to be applied on the Z axis</param>
     [LuaMethod("ship.applyRotDependentForce")]
-    public static void ApplyRotDependentForce(double forceX, double forceY, double forceZ) => default;
+    public static void ApplyRotDependentForce(double forceX, double forceY, double forceZ) { }
 
     /// <summary>
     /// Applies a rotation-dependent torque to the Ship on the next physics tick
     /// </summary>
     /// <param name="torque">The torque to be applied</param>
     [LuaMethod("ship.applyRotDependentTorque")]
-    public static void ApplyRotDependentTorque(Vector3 torque) => default;
+    public static void ApplyRotDependentTorque(Vector3 torque) { }
     /// <summary>
     /// Applies a rotation-dependent torque to the Ship on the next physics tick
     /// </summary>
@@ -295,7 +295,7 @@ public class Ship
     /// <param name="torqueY">The torque to be applied on the Y axis</param>
     /// <param name="torqueZ">The torque to be applied on the Z axis</param>
     [LuaMethod("ship.applyRotDependentTorque")]
-    public static void ApplyRotDependentTorque(double torqueX, double torqueY, double torqueZ) => default;
+    public static void ApplyRotDependentTorque(double torqueX, double torqueY, double torqueZ) { }
 
     /// <summary>
     /// Applies a rotation-dependent force to the Ship at the given local offset on the next physics tick
@@ -303,7 +303,7 @@ public class Ship
     /// <param name="force">The force to be applied</param>
     /// <param name="pos">The local offset ot apply the force to</param>
     [LuaMethod("ship.applyRotDependentForceToPos")]
-    public static void ApplyRotDependentForceToPosition(Vector3 force, Vector3 pos) => default;
+    public static void ApplyRotDependentForceToPosition(Vector3 force, Vector3 pos) { }
     /// <summary>
     /// Applies a rotation-dependent force to the Ship at the given local offset on the next physics tick
     /// </summary>
@@ -314,7 +314,7 @@ public class Ship
     /// <param name="posY">The local Y-axis offset to apply the force to</param>
     /// <param name="posZ">The local Z-axis offset to apply the force to</param>
     [LuaMethod("ship.applyRotDependentForceToPos")]
-    public static void ApplyRotDependentForceToPosition(double forceX, double forceY, double forceZ, double posX, double posY, double posZ) => default;
+    public static void ApplyRotDependentForceToPosition(double forceX, double forceY, double forceZ, double posX, double posY, double posZ) { }
 
     /// <summary>
     /// The base constraint data class

--- a/src/CCSharp/CCVS/Ship.cs
+++ b/src/CCSharp/CCVS/Ship.cs
@@ -48,7 +48,7 @@ public class Ship
     /// </summary>
     /// <param name="static">Whether the Ship should be static</returns>
     [LuaMethod("ship.setStatic")]
-    public static bool SetStatic(bool static) => default;
+    public static void SetStatic(bool static) { }
 
     /// <summary>
     /// Gets all Constraints affecting the Ship

--- a/src/CCSharp/CCVS/Ship.cs
+++ b/src/CCSharp/CCVS/Ship.cs
@@ -134,7 +134,7 @@ public class Ship
     /// <param name="pos">The Shipyard position on the Ship</param>
     /// <returns>The Worldspace position</returns>
     [LuaMethod("ship.transformPositionToWorld")]
-    public static Vector3 transformPositionToWorld(Vector3 pos) => default;
+    public static Vector3 TransformPositionToWorld(Vector3 pos) => default;
 
     /// <summary>
     /// Holds the thread while awaiting the "physics_ticks" event

--- a/src/CCSharp/CCVS/Ship.cs
+++ b/src/CCSharp/CCVS/Ship.cs
@@ -1,0 +1,253 @@
+using CCSharp.Attributes;
+using CCSharp.ComputerCraft;
+using CCSharp.AdvancedMath;
+
+namespace CCSharp.CCVS;
+
+public class Ship
+{
+    [LuaMethod("ship.getId")]
+    public static Long GetId() => default;
+
+    [LuaMethod("ship.getSlug")]
+    public static string GetSlug() => default;
+
+    [LuaMethod("ship.setSlug")]
+    public static void SetSlug(string slug) => default;
+
+    [LuaMethod("ship.getMass")]
+    public static double GetMass() => default;
+
+    [LuaMethod("ship.isStatic")]
+    public static bool IsStatic() => default;
+
+    [LuaMethod("ship.getConstraints")]
+    public static Dictionary<Long, Constraint> GetConstraints() => default;
+
+    [LuaMethod("ship.getShipyardPosition")]
+    public static Vector3 GetShipyardPosition() => default;
+
+    [LuaMethod("ship.getWorldspacePosition")]
+    public static Vector3 GetWorldspacePosition() => default;
+
+    [LuaMethod("ship.getVelocity")]
+    public static Vector3 GetLinearVelocity() => default;
+
+    [LuaMethod("ship.getOmega")]
+    public static Vector3 GetAngularVelocity() => default;
+
+    [LuaMethod("ship.getScale")]
+    public static Vector3 GetScale() => default;
+
+    [LuaMethod("ship.setScale")]
+    public static void SetScale(double scale) => default;
+
+    [LuaMethod("ship.getQuaternion")]
+    public static Quaternion GetQuaternion() => default;
+
+    [LuaMethod("ship.getTransformationMatrix")]
+    public static Matrix GetTransformationMatrix() => default;
+
+    [LuaMethod("ship.getMomentOfInertiaTensorToSave")]
+    public static Matrix GetMomentOfInertiaTensorToSave() => default;
+
+    [LuaMethod("ship.getMomentOfInertiaTensor")]
+    public static Matrix GetMomentOfInertiaTensor() => default;
+
+    [LuaMethod("ship.transformPositionToWorld")]
+    public static Vector3 transformPositionToWorld(Vector3 pos) => default;
+
+    [LuaMethod("ship.pullPhysicsTicks")]
+    public static (string name, PhysicsTick[] ticks) PullPhysicsTicks() => default;
+
+    [LuaTableTypeCheck(TableAccessor = "getBuoyantFactor"), LuaTableTypeCheck(TableAccessor = "isStatic"), LuaTableTypeCheck(TableAccessor = "doFluidDrag"), LuaTableTypeCheck(TableAccessor = "getInertia"), LuaTableTypeCheck(TableAccessor = "getPoseVel"), LuaTableTypeCheck(TableAccessor = "getForceInducers")]
+    class PhysicsTick
+    {
+        [LuaMethod("getBuoyantFactor")]
+        public double GetBuoyantFactor() => default;
+
+        [LuaMethod("isStatic")]
+        public bool IsStatic() => default;
+
+        [LuaMethod("doFluidDrag")]
+        public bool FluidDrag() => default;
+
+        [LuaMethod("getInertia")]
+        public Inertia GetInertia() => default;
+
+        [LuaMethod("getPoseVel")]
+        public PoseVel GetPoseVel() => default;
+
+        [LuaMethod("getForceInducers")]
+        public string[] GetForceInducers() => default;
+
+        class Inertia
+        {
+            [LuaProperty("momentOfInertiaTensor")] public Matrix MomentOfInertiaTensor { get; set; }
+            [LuaProperty("mass")] public double Mass { get; set; }
+        }
+
+        class PoseVel
+        {
+            [LuaProperty("vel")] public Vector3 LinearVelocity { get; set; }
+            [LuaProperty("omega")] public Vector3 AngularVelocity { get; set; }
+            [LuaProperty("pos")] public Vector3 CenterOfMass { get; set; }
+            [LuaProperty("rot")] public Quaternion Rotation { get; set; }
+        }
+
+    }
+
+    [LuaMethod("ship.teleport")]
+    public static void Teleport(object data) => default;
+
+    [LuaMethod("ship.applyInvariantForce")]
+    public static void ApplyInvariantForce(Vector3 force) => default;
+    [LuaMethod("ship.applyInvariantForce")]
+    public static void ApplyInvariantForce(double forceX, double forceY, double forceZ) => default;
+
+    [LuaMethod("ship.applyInvariantTorque")]
+    public static void ApplyInvariantTorque(Vector3 torque) => default;
+    [LuaMethod("ship.applyInvariantTorque")]
+    public static void ApplyInvariantTorque(double torqueX, double torqueY, double torqueZ) => default;
+
+    [LuaMethod("ship.applyInvariantForceToPos")]
+    public static void ApplyInvariantForceToPosition(Vector3 force, Vector3 pos) => default;
+    [LuaMethod("ship.applyInvariantForceToPos")]
+    public static void ApplyInvariantForceToPosition(double forceX, double forceY, double forceZ, double posX, double posY, double posZ) => default;
+
+    [LuaMethod("ship.applyRotDependentForce")]
+    public static void ApplyRotDependentForce(Vector3 force) => default;
+    [LuaMethod("ship.applyRotDependentForce")]
+    public static void ApplyRotDependentForce(double forceX, double forceY, double forceZ) => default;
+
+    [LuaMethod("ship.applyRotDependentTorque")]
+    public static void ApplyRotDependentTorque(Vector3 torque) => default;
+    [LuaMethod("ship.applyRotDependentTorque")]
+    public static void ApplyRotDependentTorque(double torqueX, double torqueY, double torqueZ) => default;
+
+    [LuaMethod("ship.applyRotDependentForceToPos")]
+    public static void ApplyRotDependentForceToPosition(Vector3 force, Vector3 pos) => default;
+    [LuaMethod("ship.applyRotDependentForceToPos")]
+    public static void ApplyRotDependentForceToPosition(double forceX, double forceY, double forceZ, double posX, double posY, double posZ) => default;
+
+    [LuaTableTypeCheck(TableAccessor = "type")]
+    class Constraint
+    {
+        [LuaEnum(typeof(ConstraintType))]
+        public enum ConstraintType
+        {
+            [LuaEnumValue("attachment")] Attachment,
+            [LuaEnumValue("fixed_attachment_orientation")] FixedAttachmentOrientation,
+            [LuaEnumValue("fixed_orientation")] FixedOrientation,
+            [LuaEnumValue("hinge_orientation")] HingeOrientation,
+            [LuaEnumValue("hinge_swing_limits")] HingeSwingLimits,
+            [LuaEnumValue("hinge_target_angle")] HingeTargetAngle,
+            [LuaEnumValue("pos_damping")] PosDamping,
+            [LuaEnumValue("rope")] Rope,
+            [LuaEnumValue("rot_damping")] RotDamping,
+            [LuaEnumValue("Slide")] Slide,
+            [LuaEnumValue("spherical_swing_limits")] SphericalSwingLimits,
+            [LuaEnumValue("spherical_twist_limits")] SphericalTwistLimits
+        }
+
+        [LuaProperty("shipId0")] public Long FirstShipID { get; set; }
+        [LuaProperty("shipId1")] public Long SecondShipID { get; set; }
+        [LuaProperty("type")] public ConstraintType Type { get; set; }
+        [LuaProperty("compliance")] public double Compliance { get; set; }
+    }
+
+    [LuaImplicitTypeArgument("type")]
+    class AttachmentConstraint : Constraint
+    {
+        [LuaProperty("localPos0")] public Vector3 FirstPosition { get; set; }
+        [LuaProperty("localPos1")] public Vector3 SecondPosition { get; set; }
+        [LuaProperty("maxForce")] public double MaxForce { get; set; }
+        [LuaProperty("fixedDistance")] public double FixedDistance { get; set; }
+    }
+
+    [LuaImplicitTypeArgument("type")]
+    class HingeSwingLimitsConstraint : Constraint
+    {
+        [LuaProperty("localRot0")] public Quaternion FirstPosition { get; set; }
+        [LuaProperty("localRot1")] public Quaternion SecondPosition { get; set; }
+        [LuaProperty("maxTorque")] public double MaxTorque { get; set; }
+        [LuaProperty("minSwingAngle")] public double MinSwingAngle { get; set; }
+        [LuaProperty("maxSwingAngle")] public double MaxSwingAngle { get; set; }
+    }
+
+    [LuaImplicitTypeArgument("type")]
+    class HingeTargetAngleConstraint : Constraint
+    {
+        [LuaProperty("localRot0")] public Quaternion FirstPosition { get; set; }
+        [LuaProperty("localRot1")] public Quaternion SecondPosition { get; set; }
+        [LuaProperty("maxTorque")] public double MaxTorque { get; set; }
+        [LuaProperty("targetAngle")] public double TargetAngle { get; set; }
+        [LuaProperty("nextTickTargetAngle")] public double NextTickTargetAngle { get; set; }
+    }
+
+    [LuaImplicitTypeArgument("type")]
+    class PosDampingConstraint : Constraint
+    {
+        [LuaProperty("localPos0")] public Vector3 FirstPosition { get; set; }
+        [LuaProperty("localPos1")] public Vector3 SecondPosition { get; set; }
+        [LuaProperty("maxForce")] public double MaxForce { get; set; }
+        [LuaProperty("posDamping")] public double PosDamping { get; set; }
+    }
+
+    [LuaImplicitTypeArgument("type")]
+    class RopeConstraint : Constraint
+    {
+        [LuaProperty("localPos0")] public Vector3 FirstPosition { get; set; }
+        [LuaProperty("localPos1")] public Vector3 SecondPosition { get; set; }
+        [LuaProperty("maxForce")] public double MaxForce { get; set; }
+        [LuaProperty("ropeLength")] public double RopeLength { get; set; }
+    }
+
+    [LuaImplicitTypeArgument("type")]
+    class RotDampingConstraint : Constraint
+    {
+        [LuaEnum(typeof(RotDampingAxes))]
+        public enum RotDampingAxes
+        {
+            [LuaEnumValue("parallel")] Parallel,
+            [LuaEnumValue("perpendicular")] Perpendicular,
+            [LuaEnumValue("all_axes")] AllAxes
+        }
+
+        [LuaProperty("localPos0")] public Vector3 FirstPosition { get; set; }
+        [LuaProperty("localPos1")] public Vector3 SecondPosition { get; set; }
+        [LuaProperty("maxForce")] public double MaxForce { get; set; }
+        [LuaProperty("rotDamping")] public double RotDamping { get; set; }
+        [LuaProperty("rotDampingAxes")] public RotDampingAxes RotDampingAxis { get; set; }
+    }
+
+    [LuaImplicitTypeArgument("type")]
+    class RotDampingConstraint : Constraint
+    {
+        [LuaProperty("localPos0")] public Vector3 FirstPosition { get; set; }
+        [LuaProperty("localPos1")] public Vector3 SecondPosition { get; set; }
+        [LuaProperty("maxForce")] public double MaxForce { get; set; }
+        [LuaProperty("localSlideAxis0")] public Vector3 LocalSlideAxis { get; set; }
+        [LuaProperty("maxDistBetweenPoints")] public double MaxDistanceBetweenPoints { get; set; }
+    }
+
+    [LuaImplicitTypeArgument("type")]
+    class SphericalSwingLimitsConstraint : Constraint
+    {
+        [LuaProperty("localRot0")] public Quaternion FirstPosition { get; set; }
+        [LuaProperty("localRot1")] public Quaternion SecondPosition { get; set; }
+        [LuaProperty("maxTorque")] public double MaxTorque { get; set; }
+        [LuaProperty("minSwingAngle")] public double MinSwingAngle { get; set; }
+        [LuaProperty("maxSwingAngle")] public double MaxSwingAngle { get; set; }
+    }
+
+    [LuaImplicitTypeArgument("type")]
+    class SphericalTwistLimitsConstraint : Constraint
+    {
+        [LuaProperty("localRot0")] public Quaternion FirstPosition { get; set; }
+        [LuaProperty("localRot1")] public Quaternion SecondPosition { get; set; }
+        [LuaProperty("maxTorque")] public double MaxTorque { get; set; }
+        [LuaProperty("minTwistAngle")] public double MinTwistAngle { get; set; }
+        [LuaProperty("maxTwistAngle")] public double MaxTwistAngle { get; set; }
+    }
+}


### PR DESCRIPTION
This PR adds a few new classes for compatibility between CCSharp and [CC: Advanced Math](https://github.com/TechTastic/Advanced-Math) and [CC: VS](https://github.com/TechTastic/CC-VS/blob/1.20.x/main/common/src/main/resources/data/computercraft/lua/rom/apis/ship.lua) under appropriate namespaces for proper separation

## CC: Advanced Math
- `Quaternion.cs`
- `Matrix.cs`
- `PID.cs`
- `MMath.cs`
## CC: VS
- `Ship.cs`